### PR TITLE
Fix swapped parameters for gl.drawArrays()

### DIFF
--- a/libs/framework.js
+++ b/libs/framework.js
@@ -854,7 +854,7 @@ function modelRenderer(model) {
       gl.drawElements(gl.TRIANGLES, numItems, gl.UNSIGNED_SHORT, 0);
     }
     else {
-      gl.drawArrays(gl.TRIANGLES, numItems, 0);
+      gl.drawArrays(gl.TRIANGLES, 0, numItems);
     }
   };
 }


### PR DESCRIPTION
Changes the parameters of gl.drawArrays() to match the [documentation](https://www.opengl.org/sdk/docs/man/html/glDrawArrays.xhtml) where the second parameter is the first index and the third is the number of elements to draw.